### PR TITLE
simple fix

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-flask
+flask==1.0.2
 python-telegram-bot


### PR DESCRIPTION
fix for error `Unable to import module 'vc__handler__python': cannot import name 'ContextVar'`
Source: [Here](https://vercel.com/docs/runtimes#advanced-usage/advanced-python-usage)